### PR TITLE
fix pod

### DIFF
--- a/lib/Text/Diff/Table.pm
+++ b/lib/Text/Diff/Table.pm
@@ -307,7 +307,7 @@ package Text::Diff::Table{
 
 }
 
-=begin
+=begin pod
 
 =head1 NAME
 
@@ -405,4 +405,4 @@ version, or the Artistic license.
 
 =cut
 
-=end
+=end pod


### PR DESCRIPTION
This fixes:
===SORRY!=== Error while compiling lib/Text/Diff/Table.pm
=begin must be followed by an identifier; (did you mean "=begin pod"?)
at lib/Text/Diff/Table.pm:310
------> =begin⏏<EOL>
